### PR TITLE
Fix gap on right side in mobile views

### DIFF
--- a/src/assets/css/modules/_home.scss
+++ b/src/assets/css/modules/_home.scss
@@ -216,6 +216,7 @@
                     }
                 }
                 .visual {
+                    overflow-x: hidden;
                     table {
                         margin: 0px auto;
                         width: 75%;


### PR DESCRIPTION
Bug is able to be seen in Firefox and mobile devices, not Chrome. This should fix the table from causing a gap on the right side of the screen. Let me know if any other UI oddities arise.