### PR TITLE
Fix package.json and guides links

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "serve-favicon": "2.5.0",
     "spdy": "^3.4.7",
     "style-loader": "0.20.3",
+    "supports-color": "^5.4.0",
     "sw-precache-webpack-plugin": "^0.11.5",
     "webpack": "^3",
     "xss-filters": "^1.2.7"

--- a/src/docs/guides/benefits/list-rendering.md
+++ b/src/docs/guides/benefits/list-rendering.md
@@ -95,4 +95,4 @@ render(<MyComponent />, root)
 
 In the above example MyComponent returns div which has a special attribute `$HasKeyedChildren`. This attribute changes vNode flags to tell Inferno its children are always keyed.
 This results in better runtime performance. If the shape of children needs to be changed runtime then there is special property called `$ChildFlag={exoression}`. JSX specific children values are `$HasKeyedChildren`, `$HasNonKeyedChildren` and `$HasVNodeChildren`.
-When not using JSX, children properties can be defined using [inferno-vnode-flags](http://localhost:8080/docs/api/inferno-vnode-flags). See its documentation for more information.
+When not using JSX, children properties can be defined using [inferno-vnode-flags](/docs/api/inferno-vnode-flags). See its documentation for more information.

--- a/src/docs/guides/optimizations.md
+++ b/src/docs/guides/optimizations.md
@@ -49,7 +49,7 @@ When defining children flags children is/are:
 - `ChildFlags.HasKeyedChildren` (JSX **$HasKeyedChildren**) is Array of vNodes keyed (no nesting, no holes)
 
 Also when children shape if pre-defined make sure that:
-- `HasKeyedChildren` and `HasNonKeyedChildren` bits are set as needed (this depends on user land implementation see [Lists & keys](http://localhost:8080/docs/guides/benefits/list-rendering) for more information)
+- `HasKeyedChildren` and `HasNonKeyedChildren` bits are set as needed (this depends on user land implementation see [Lists & keys](/docs/guides/benefits/list-rendering) for more information)
 - Children shape must always match children when shape is defined, if children shape is dynamic you can simply switch the bit on/off. Or in JSX use `$ChildFlag={expression}` to set the bit.
 - Children structure must always be single level array or single vNode
 


### PR DESCRIPTION
* Add supports-color in package.json to avoid error during `npm install`
* Fix static `http://localhost:8080` links in guides (changed to relative paths)

## Note
The `npm install` failed on my MacBook pro (macOS High Sierra 10.13.3) with freshly installed node + npm (node v8.11.1 and npm v6.0.0, npm was updated after node install with `sudo npm i -g npm`)

The error output is :
```
MacBook-Pro-Corentin:inferno-website myaccount$ npm install
npm WARN deprecated http2@3.3.7: Use the built-in module in node 9.0.0 or newer, instead
npm WARN bootstrap@4.1.0 requires a peer of jquery@1.9.1 - 3 but none is installed. You must install peer dependencies yourself.
npm WARN bootstrap@4.1.0 requires a peer of popper.js@^1.14.0 but none is installed. You must install peer dependencies yourself.
npm WARN ajv-keywords@3.2.0 requires a peer of ajv@^6.0.0 but none is installed. You must install peer dependencies yourself.

npm ERR! path /Users/axopen/Documents/Programmation/inferno-website/node_modules/nodemon/node_modules/supports-color
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall rename
npm ERR! enoent ENOENT: no such file or directory, rename '/Users/axopen/Documents/Programmation/inferno-website/node_modules/nodemon/node_modules/supports-color' -> '/Users/axopen/Documents/Programmation/inferno-website/node_modules/nodemon/node_modules/.supports-color.DELETE'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/axopen/.npm/_logs/2018-05-03T07_53_23_426Z-debug.log
MacBook-Pro-Corentin:inferno-website axopen$ npm install support-color
npm ERR! code E404
npm ERR! 404 Not Found: support-color@latest

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/axopen/.npm/_logs/2018-05-03T07_55_50_051Z-debug.log
MacBook-Pro-Corentin:inferno-website axopen$ npm install --save supports-color
npm notice created a lockfile as package-lock.json. You should commit this file.
removed 534 packages and moved 2 packages in 4.822s
```

Adding the supports-color in `package.json` fixed the issue (tested from clean state again)