### PR TITLE
Fix unclosed parenthesis in example

### DIFF
--- a/src/docs/guides/components.md
+++ b/src/docs/guides/components.md
@@ -207,7 +207,7 @@ class AjaxComponent extends Component {
       <ul>
         {this.state.data.map(data => (
           <li>{data.name}</li>
-        )}
+        ))}
       </ul>
     )
   }


### PR DESCRIPTION
Hi!
Just a quick fix for the `components` guide.