### PR TITLE
Fix broken syntax highlighting #136

### DIFF
--- a/src/assets/styles/_docs.scss
+++ b/src/assets/styles/_docs.scss
@@ -1,3 +1,5 @@
+@import 'prismjs/themes/prism-tomorrow';
+
 .docs {
   flex-wrap: nowrap;
   flex-direction: row;
@@ -168,73 +170,4 @@
       }
     }
   }
-}
-
-/**
- * prism.js default theme for JavaScript, CSS and HTML
- * Based on dabblet (http://dabblet.com)
- * @author Lea Verou
- */
-code[class*="language-"],
-pre[class*="language-"] {
-  color: black;
-  background: none;
-  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  word-wrap: normal;
-  line-height: 1.5;
-
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
-  tab-size: 4;
-
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-}
-
-pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
-code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-  background: #b3d4fc;
-}
-
-pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
-code[class*="language-"]::selection, code[class*="language-"] ::selection {
-  text-shadow: none;
-  background: #b3d4fc;
-}
-
-@media print {
-  code[class*="language-"],
-  pre[class*="language-"] {
-    text-shadow: none;
-  }
-}
-
-/* Code blocks */
-pre[class*="language-"] {
-  padding: 1em;
-  margin: .5em 0;
-  overflow: auto;
-}
-
-:not(pre) > code[class*="language-"],
-pre[class*="language-"] {
-  background: #f5f2f0;
-}
-
-/* Inline code */
-:not(pre) > code[class*="language-"] {
-  padding: .1em;
-  border-radius: .3em;
-  white-space: normal;
-}
-
-.namespace {
-  opacity: .7;
 }


### PR DESCRIPTION
Imported the proper prismjs css file to fix the broken syntax highlighting.

Before:
<img width="1624" alt="before-inferno" src="https://user-images.githubusercontent.com/40759683/67355890-69356e00-f50d-11e9-9b00-cb25496a5d97.png">

After:
<img width="1625" alt="after-inferno" src="https://user-images.githubusercontent.com/40759683/67355941-84a07900-f50d-11e9-9d79-1d042e13d99f.png">
