### PR TITLE
Updated benchmark page

### DIFF
--- a/src/components/Benchmarks.js
+++ b/src/components/Benchmarks.js
@@ -109,35 +109,6 @@ export default class Benchmarks extends Component {
           ]
         },
         {
-          id: 'vdom',
-          name: 'Virtual DOM',
-          description: 'The Virtual DOM Benchmark focuses on testing the children reconciliation algorithm used in various libraries. It is used by virtual DOM library authors to help optimize their algorithms. While not a perfect gauge of overall performance, it tests a key ingredient of popular Virtual DOM libraries.',
-          link: 'https://vdom-benchmark.github.io/vdom-benchmark/',
-          data: [
-            {
-              label: 'Inferno JS',
-              bg: '#dc0030',
-              score: 1
-            },
-            {
-              label: 'React 15.4',
-              score: 4.06
-            },
-            {
-              label: 'Mithril',
-              score: 6.00
-            },
-            {
-              label: 'virtual-dom',
-              score: 3.20
-            },
-            {
-              label: 'snabbdom',
-              score: 1.94
-            }
-          ]
-        },
-        {
           id: 'uibench',
           name: 'UI Bench',
           description: 'UI Benchmark is considered a more accurate test of overall UI performance in a library. The tests were run with Full Render Time enabled and 5 Iterations. Read UI Benchmark\'s notes for caveats and stipulations before drawing further conclusions.',

--- a/src/components/Benchmarks.js
+++ b/src/components/Benchmarks.js
@@ -16,7 +16,7 @@ export default class Benchmarks extends Component {
         {
           id: 'frameworks',
           name: 'JS Framework',
-          description: 'The js-framework-benchmark is a simple benchmark, comparing various typical app operations for several JavaScript frameworks. The benchmarks creates a large table with randomized entries and measures the time for various operations.',
+          description: 'The js-framework-benchmark is a simple benchmark, comparing various typical app operations for several JavaScript frameworks. The benchmarks creates a large table with randomized entries and measures the time for various operations – lower is better.',
           link: 'https://github.com/krausest/js-framework-benchmark',
           data: [
             {
@@ -24,36 +24,41 @@ export default class Benchmarks extends Component {
               score: 1.0
             },
             {
-              label: 'Inferno 7.1.2',
+              label: 'Inferno 5.3.0',
               bg: '#dc0030',
-              score: 1.14
+              score: 1.06
             },
             {
               label: 'Preact 8.2.6',
-              score: 1.48
+              score: 1.29
             },
             {
-              label: 'Vue 2.6.2',
-              score: 1.72
+              label: 'Vue 2.5.16',
+              score: 1.37
             },
             {
-              label: 'React 16.8.3',
-              score: 1.75
+              label: 'Svelte 2.9.7',
+              score: 1.39
+            },
+
+            {
+              label: 'React 16.4.1',
+              score: 1.50
             },
             {
-              label: 'Angular 7.1.4',
-              score: 1.77
+              label: 'Angular 6.1.0',
+              score: 1.50
             },
             {
-              label: 'Ember 3.9.1',
-              score: 2.52
+              label: 'Marko.js 4.12.3',
+              score: 1.50
             }
           ]
         },
         {
           id: 'marko-color-picker-node',
-          name: 'Color Picker run in Node.js',
-          description: 'This simple benchmark was created by Marko.js to compare server-side rendering performance of various frameworks.',
+          name: 'Color Picker (Server)',
+          description: 'This simple benchmark was created by Marko.js to compare server-side rendering performance of various frameworks – numbers show ops/sec, higher is better.',
           link: 'https://github.com/marko-js/isomorphic-ui-benchmarks',
           data: [
             {
@@ -66,7 +71,7 @@ export default class Benchmarks extends Component {
               score: 24540
             },
             {
-              label: 'Preact',
+              label: 'Preact 10.0.1',
               score: 4587
             },
             {
@@ -81,8 +86,8 @@ export default class Benchmarks extends Component {
         },
         {
           id: 'marko-color-picker-chrome',
-          name: 'Color Picker run in Chrome',
-          description: 'This simple benchmark was created by Marko.js to compare client-side rendering performance of various frameworks.',
+          name: 'Color Picker (Chrome)',
+          description: 'This simple benchmark was created by Marko.js to compare client-side rendering performance of various frameworks – numbers show ops/sec, higher is better.',
           link: 'https://github.com/marko-js/isomorphic-ui-benchmarks',
           data: [
             {
@@ -95,7 +100,7 @@ export default class Benchmarks extends Component {
               score: 6008
             },
             {
-              label: 'Preact',
+              label: 'Preact 10.0.1',
               score: 6435
             },
             {
@@ -111,7 +116,7 @@ export default class Benchmarks extends Component {
         {
           id: 'uibench',
           name: 'UI Bench',
-          description: 'UI Benchmark is considered a more accurate test of overall UI performance in a library. The tests were run with Full Render Time enabled and 5 Iterations. Read UI Benchmark\'s notes for caveats and stipulations before drawing further conclusions.',
+          description: 'UI Benchmark is considered a more accurate test of overall UI performance in a library. The tests were run with Full Render Time enabled and 5 Iterations. Read UI Benchmark\'s notes for caveats and stipulations before drawing further conclusions – lower is better.',
           link: 'https://localvoid.github.io/uibench/',
           data: [
             {

--- a/src/components/Benchmarks.js
+++ b/src/components/Benchmarks.js
@@ -16,7 +16,7 @@ export default class Benchmarks extends Component {
         {
           id: 'marko-color-picker-chrome',
           name: 'Color Picker (Chrome)',
-          description: 'This simple benchmark was created by Marko.js to compare client-side rendering performance of various frameworks – numbers show ops/sec, higher is better.',
+          description: 'This benchmark was created by Marko.js to compare client-side rendering performance of various frameworks – numbers show ops/sec, higher is better.',
           link: 'https://github.com/marko-js/isomorphic-ui-benchmarks',
           data: [
             {
@@ -45,7 +45,7 @@ export default class Benchmarks extends Component {
         {
           id: 'marko-color-picker-node',
           name: 'Color Picker (Server)',
-          description: 'This simple benchmark was created by Marko.js to compare server-side rendering performance of various frameworks – numbers show ops/sec, higher is better.',
+          description: 'This benchmark was created by Marko.js to compare server-side rendering performance of various frameworks – numbers show ops/sec, higher is better.',
           link: 'https://github.com/marko-js/isomorphic-ui-benchmarks',
           data: [
             {

--- a/src/components/Benchmarks.js
+++ b/src/components/Benchmarks.js
@@ -15,9 +15,9 @@ export default class Benchmarks extends Component {
       list: [
         {
           id: 'frameworks',
-          name: 'JS Frameworks',
-          description: 'The JS web frameworks benchmark is a simple benchmark, comparing various typical app operations for several JavaScript frameworks. The benchmarks creates a large table with randomized entries and measures the time for various operations.',
-          link: 'https://vdom-benchmark.github.io/vdom-benchmark/',
+          name: 'JS Framework',
+          description: 'The js-framework-benchmark is a simple benchmark, comparing various typical app operations for several JavaScript frameworks. The benchmarks creates a large table with randomized entries and measures the time for various operations.',
+          link: 'https://github.com/krausest/js-framework-benchmark',
           data: [
             {
               label: 'Vanilla JS',

--- a/src/components/Benchmarks.js
+++ b/src/components/Benchmarks.js
@@ -14,6 +14,64 @@ export default class Benchmarks extends Component {
       current: 0,
       list: [
         {
+          id: 'marko-color-picker-chrome',
+          name: 'Color Picker (Chrome)',
+          description: 'This simple benchmark was created by Marko.js to compare client-side rendering performance of various frameworks – numbers show ops/sec, higher is better.',
+          link: 'https://github.com/marko-js/isomorphic-ui-benchmarks',
+          data: [
+            {
+              label: 'Inferno 7.3.2',
+              bg: '#dc0030',
+              score: 17078
+            },
+            {
+              label: 'Marko.js 4.18.16',
+              score: 6008
+            },
+            {
+              label: 'Preact 10.0.1',
+              score: 6435
+            },
+            {
+              label: 'React 16.10.2',
+              score: 7358
+            },
+            {
+              label: 'Vue 2.6.10',
+              score: 4291
+            }
+          ]
+        },
+        {
+          id: 'marko-color-picker-node',
+          name: 'Color Picker (Server)',
+          description: 'This simple benchmark was created by Marko.js to compare server-side rendering performance of various frameworks – numbers show ops/sec, higher is better.',
+          link: 'https://github.com/marko-js/isomorphic-ui-benchmarks',
+          data: [
+            {
+              label: 'Inferno 7.3.2',
+              bg: '#dc0030',
+              score: 21453
+            },
+            {
+              label: 'Marko.js 4.18.16',
+              score: 24540
+            },
+            {
+              label: 'Preact 10.0.1',
+              score: 4587
+            },
+            {
+              label: 'React 16.10.2',
+              score: 4300
+            },
+            {
+              label: 'Vue 2.6.10',
+              score: 9120
+            }
+          ]
+        },
+        {
           id: 'frameworks',
           name: 'JS Framework',
           description: 'The js-framework-benchmark is a simple benchmark, comparing various typical app operations for several JavaScript frameworks. The benchmarks creates a large table with randomized entries and measures the time for various operations – lower is better.',
@@ -52,64 +110,6 @@ export default class Benchmarks extends Component {
             {
               label: 'Marko.js 4.12.3',
               score: 1.50
-            }
-          ]
-        },
-        {
-          id: 'marko-color-picker-node',
-          name: 'Color Picker (Server)',
-          description: 'This simple benchmark was created by Marko.js to compare server-side rendering performance of various frameworks – numbers show ops/sec, higher is better.',
-          link: 'https://github.com/marko-js/isomorphic-ui-benchmarks',
-          data: [
-            {
-              label: 'Inferno 7.3.2',
-              bg: '#dc0030',
-              score: 21453
-            },
-            {
-              label: 'Marko.js 4.18.16',
-              score: 24540
-            },
-            {
-              label: 'Preact 10.0.1',
-              score: 4587
-            },
-            {
-              label: 'React 16.10.2',
-              score: 4300
-            },
-            {
-              label: 'Vue 2.6.10',
-              score: 9120
-            }
-          ]
-        },
-        {
-          id: 'marko-color-picker-chrome',
-          name: 'Color Picker (Chrome)',
-          description: 'This simple benchmark was created by Marko.js to compare client-side rendering performance of various frameworks – numbers show ops/sec, higher is better.',
-          link: 'https://github.com/marko-js/isomorphic-ui-benchmarks',
-          data: [
-            {
-              label: 'Inferno 7.3.2',
-              bg: '#dc0030',
-              score: 17078
-            },
-            {
-              label: 'Marko.js 4.18.16',
-              score: 6008
-            },
-            {
-              label: 'Preact 10.0.1',
-              score: 6435
-            },
-            {
-              label: 'React 16.10.2',
-              score: 7358
-            },
-            {
-              label: 'Vue 2.6.10',
-              score: 4291
             }
           ]
         },

--- a/src/components/Benchmarks.js
+++ b/src/components/Benchmarks.js
@@ -51,6 +51,64 @@ export default class Benchmarks extends Component {
           ]
         },
         {
+          id: 'marko-color-picker-node',
+          name: 'Color Picker run in Node.js',
+          description: 'This simple benchmark was created by Marko.js to compare server-side rendering performance of various frameworks.',
+          link: 'https://github.com/marko-js/isomorphic-ui-benchmarks',
+          data: [
+            {
+              label: 'Inferno 7.3.2',
+              bg: '#dc0030',
+              score: 21453
+            },
+            {
+              label: 'Marko.js 4.18.16',
+              score: 24540
+            },
+            {
+              label: 'Preact',
+              score: 4587
+            },
+            {
+              label: 'React 16.10.2',
+              score: 4300
+            },
+            {
+              label: 'Vue 2.6.10',
+              score: 9120
+            }
+          ]
+        },
+        {
+          id: 'marko-color-picker-chrome',
+          name: 'Color Picker run in Chrome',
+          description: 'This simple benchmark was created by Marko.js to compare client-side rendering performance of various frameworks.',
+          link: 'https://github.com/marko-js/isomorphic-ui-benchmarks',
+          data: [
+            {
+              label: 'Inferno 7.3.2',
+              bg: '#dc0030',
+              score: 17078
+            },
+            {
+              label: 'Marko.js 4.18.16',
+              score: 6008
+            },
+            {
+              label: 'Preact',
+              score: 6435
+            },
+            {
+              label: 'React 16.10.2',
+              score: 7358
+            },
+            {
+              label: 'Vue 2.6.10',
+              score: 4291
+            }
+          ]
+        },
+        {
           id: 'vdom',
           name: 'Virtual DOM',
           description: 'The Virtual DOM Benchmark focuses on testing the children reconciliation algorithm used in various libraries. It is used by virtual DOM library authors to help optimize their algorithms. While not a perfect gauge of overall performance, it tests a key ingredient of popular Virtual DOM libraries.',


### PR DESCRIPTION
Added the two Marko.js benchmarks and removed Virtual DOM Benchmark because it is marked as obsolete. Updated some copy, fixed a link and updated numbers for js-framework-benchmark, I couldn't find where the current ones come from. 