### PR TITLE
Fixing intra-page anchors

### DIFF
--- a/src/docs/guides/libraries.md
+++ b/src/docs/guides/libraries.md
@@ -327,6 +327,8 @@ function notConnectedToStoreFunc() {
 }
 ```
 
+<a name="inferno-carousel"></a>
+
 ## inferno-carousel
 
 Carousel component for InfernoJS.
@@ -370,6 +372,8 @@ You can also specify a `className` for the container of the carousel by providin
 
 - `animationSpeed` is the speed (in terms of milliseconds) of the transition animation.
 - `itemDuration` is the amount of time (in terms of milliseconds) it has to wait before transitioning to the next item.
+
+<a name="inferno-particles"></a>
 
 ## inferno-particles
 


### PR DESCRIPTION
Two TOC links did not have an associated anchor, meaning that MD editors would jump to the header with the matching string, but browsers would not go anywhere since they rely on the explicit anchor.