### PR TITLE
Update Community.js

### DIFF
--- a/src/components/common/Community.js
+++ b/src/components/common/Community.js
@@ -10,8 +10,8 @@ export function Community() {
       </a>{' '}
       where you can ask questions and find out the latest news about Inferno
       development. You can join via{' '}
-      <a rel="nofollow" href="https://discord.gg/pYFsMTYndu">
-        https://discord.gg/pYFsMTYndu.
+      <a rel="nofollow" href="https://discord.gg/SUKuhgaBpF">
+        https://discord.gg/SUKuhgaBpF.
       </a>
     </p>,
     <h4>Contributors</h4>,


### PR DESCRIPTION
Used working Discord invite link to correct broken Discord invite link

Please ensure these are intended to be the same link. Else you will need to generate a new invite link from Discord to account for this. But I believe they are intended to be the same and were overlooked.